### PR TITLE
Added a sym link to put geth in PATH so script can resolve geth command

### DIFF
--- a/geth-dev/Dockerfile
+++ b/geth-dev/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get install -y vim
 RUN apt-get install -y net-tools
 RUN apt-get -y install npm
 RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN ln -s /geth /usr/bin/geth
 RUN apt-get -y install git
 RUN apt-get -y install curl
 RUN apt-get -y install lsof


### PR DESCRIPTION
Currently the runGeth.sh script fails as it cannot find the 'geth' command.
This sym link puts it in /usr/bin/ and Geth can therefore be resolved via the PATH.
