### PR TITLE
fix for Alpine base image package mgr changes

### DIFF
--- a/geth-dev/Dockerfile
+++ b/geth-dev/Dockerfile
@@ -1,15 +1,17 @@
 FROM ethereum/client-go
-RUN apt-get update
-RUN apt-get install -y apt-utils
-RUN apt-get install -y vim
-RUN apt-get install -y net-tools
-RUN apt-get -y install npm
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+
+# alpine sdk - curl, gcc, make, g++, git
+RUN apk add --update \
+  alpine-sdk \
+  bash \
+  vim \
+  python \
+  net-tools \
+  nodejs \
+  nodejs-npm \
+  lsof
+
 RUN ln -s /geth /usr/bin/geth
-RUN apt-get -y install git
-RUN apt-get -y install curl
-RUN apt-get -y install lsof
 RUN npm install -g pm2
 
 ENTRYPOINT ["/bin/bash"]
-


### PR DESCRIPTION
The root image has changed to Alpine which uses `apk` instead of `apt`